### PR TITLE
fixes #7, timeout value

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -32,6 +32,7 @@ var getTokens = function(callback) {
   },
   {   client_id: google_secrets.client_id, //replace with your client_id and _secret
       client_secret: google_secrets.client_secret,
+      timeout: 60 * 60 * 1000,  // This allows uploads to take up to an hour
       port: 3000
   },
   function(err, authClient, tokens) {


### PR DESCRIPTION
This shows how to have uploads that take longer than 5 minutes, in this case up to one hour.